### PR TITLE
Fetch the correct datatype as it changed from previous the previous API

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,25 +3,27 @@ import { Post } from "../post/types";
 
 export const handlers = [
   http.get(`${import.meta.env.VITE_API_URL}posts`, () => {
-    return HttpResponse.json<Post[]>([
-      {
-        id: "1",
-        author: "",
-        title: "el leon de la carcel",
-        content: "",
-        date: new Date(),
-        alternativeText: "",
-        imageUrl: "",
-      },
-      {
-        id: "2",
-        author: "",
-        title: "un elefante en la luna",
-        content: "",
-        date: new Date(),
-        alternativeText: "",
-        imageUrl: "",
-      },
-    ]);
+    return HttpResponse.json<{ posts: Post[] }>({
+      posts: [
+        {
+          id: "1",
+          author: "",
+          title: "el leon de la carcel",
+          content: "",
+          date: new Date(),
+          alternativeText: "",
+          imageUrl: "",
+        },
+        {
+          id: "2",
+          author: "",
+          title: "un elefante en la luna",
+          content: "",
+          date: new Date(),
+          alternativeText: "",
+          imageUrl: "",
+        },
+      ],
+    });
   }),
 ];

--- a/src/post/api/postsClient/PostsClient.ts
+++ b/src/post/api/postsClient/PostsClient.ts
@@ -5,11 +5,16 @@ export class PostsClient implements PostClientStructure {
   async getPost(): Promise<Post[]> {
     const apiResponse = await fetch(`${import.meta.env.VITE_API_URL}posts`);
 
-    const apiPostsDto = (await apiResponse.json()) as PostDto[];
+    const apiPostsDto = (await apiResponse.json()) as {
+      posts: PostDto[];
+    };
 
-    const posts = apiPostsDto.map<Post>((apiPostDto) => ({
-      ...apiPostDto,
-      date: new Date(apiPostDto.date),
+    const { posts: postsDto } = apiPostsDto;
+
+    const posts = postsDto.map<Post>((postDto) => ({
+      ...postDto,
+      id: postDto._id,
+      date: new Date(postDto.date),
     }));
 
     return posts;

--- a/src/post/types.ts
+++ b/src/post/types.ts
@@ -12,6 +12,7 @@ export interface Post extends PostBase {
 }
 
 export interface PostDto extends PostBase {
+  _id: string;
   date: number;
 }
 


### PR DESCRIPTION
The previous endpoint GET /posts was fetching data from a response that had the body of an array, since it migrated to a MongoDB it comes now from an object so it was needed to aim the correct datatype in order to get the posts.